### PR TITLE
Fix Wi‑Fi parser edge cases

### DIFF
--- a/Wi-Fi Scanner/utils/display.py
+++ b/Wi-Fi Scanner/utils/display.py
@@ -8,6 +8,10 @@ def display_sorted_networks(networks):
     print("Nearby Wi-Fi Networks (Sorted by Signal Strength):\n")
     for net in sorted_nets:
         print(f"SSID         : {net.get('SSID', 'N/A')}")
-        print(f"Signal       : {net.get('Signal', 'N/A')}%")
+        signal = net.get('Signal')
+        if signal is not None:
+            print(f"Signal       : {signal}%")
+        else:
+            print("Signal       : N/A")
         print(f"Security     : {net.get('Authentication', 'N/A')}")
         print("-" * 40)

--- a/Wi-Fi Scanner/utils/parser.py
+++ b/Wi-Fi Scanner/utils/parser.py
@@ -9,7 +9,10 @@ def parse_networks(output):
             if current:
                 networks.append(current)
                 current = {}
-            ssid = re.sub(r"^SSID \d+ : ", "", line)
+            # Netsh may output varying spaces around the colon. Split once on
+            # the first colon to reliably extract the SSID name regardless of
+            # formatting.
+            ssid = line.split(":", 1)[1].strip()
             current["SSID"] = ssid
         elif "Signal" in line:
             signal = int(re.sub(r"[^\d]", "", line.split(":")[1]))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+# Add the Wi-Fi Scanner directory to the path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'Wi-Fi Scanner'))
+
+from utils.parser import parse_networks
+
+SAMPLE_OUTPUT = """
+SSID 1 : TestNetwork
+    Network type            : Infrastructure
+    Authentication          : WPA2-Personal
+    Encryption              : CCMP
+    BSSID 1                 : aa:bb:cc:dd:ee:ff
+         Signal             : 80%
+         Radio type         : 802.11ac
+         Channel            : 11
+
+SSID 2 : AnotherOne
+    Network type            : Infrastructure
+    Authentication          : Open
+    Encryption              : None
+    BSSID 1                 : 00:11:22:33:44:55
+         Signal             : 60%
+"""
+
+SAMPLE_OUTPUT_VARIATION = """
+SSID 1:NoSpaces
+Authentication:WPA3
+Signal:70%
+"""
+
+def test_parse_standard_output():
+    networks = parse_networks(SAMPLE_OUTPUT)
+    assert networks == [
+        {"SSID": "TestNetwork", "Signal": 80, "Authentication": "WPA2-Personal"},
+        {"SSID": "AnotherOne", "Signal": 60, "Authentication": "Open"},
+    ]
+
+def test_parse_colon_variation():
+    networks = parse_networks(SAMPLE_OUTPUT_VARIATION)
+    assert networks == [
+        {"SSID": "NoSpaces", "Signal": 70, "Authentication": "WPA3"}
+    ]
+


### PR DESCRIPTION
## Summary
- make SSID parsing more robust for extra spaces
- avoid printing `%` when signal value is missing
- add tests covering the parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8217fe388324873d1c7b9dfe93d9