### PR TITLE
Add Windows-only notes to Wi-Fi scanner

### DIFF
--- a/Wi-Fi Scanner/utils/scanner.py
+++ b/Wi-Fi Scanner/utils/scanner.py
@@ -1,6 +1,15 @@
+"""Utilities for scanning Wi-Fi networks using Windows tools.
+
+This module relies on the ``netsh`` command that ships with Windows to
+retrieve information about nearby Wi-Fi networks. As a result, the
+functionality here is Windows-only and will not work on other operating
+systems.
+"""
+
 import subprocess
 
 def get_raw_network_data():
+    """Return raw Wi-Fi network data using the Windows ``netsh`` command."""
     try:
         output = subprocess.check_output(
             ['netsh', 'wlan', 'show', 'networks', 'mode=bssid'],


### PR DESCRIPTION
## Summary
- clarify that the Wi-Fi scanner works only on Windows by adding a module docstring
- mention the Windows `netsh` requirement in the function docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f86791e8483249b93c3d28cca003a