### PR TITLE
Fix readme wording

### DIFF
--- a/PinClone/readme.md
+++ b/PinClone/readme.md
@@ -1,3 +1,3 @@
 streamlit run app.py
 
-run it on cmd in the same file as the program.
+run it on cmd in the same folder as the program.


### PR DESCRIPTION
## Summary
- fix README wording to say *folder* rather than file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f8663b89483248fcfdb27b11bea5c